### PR TITLE
Import existing stripes components lint configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # eslint-config-stripes
 
-Stripes's .eslintrc as an extensible shared config
+This package provides an extensible shared [ESLint](https://eslint.org) config, intended to promote consistent code style among applications built with [FOLIO Stripes](https://github.com/folio-org/stripes-core).
+
+## Installation
+If you haven't already installed ESLint as a dev dependency in your project, it's a required peer of `eslint-config-stripes`:
+```
+yarn add eslint -D
+```
+
+Then add `eslint-config-stripes` to your `devDependencies`:
+```
+yarn add eslint-config-stripes -D
+```
+
+Create `.eslintrc` in the root of your project. Its contents:
+```
+{
+  "extends": "stripes"
+}
+```
+
+### Using Babel?
+If you're extensively using newer JavaScript syntax with Babel, you may want to use [`babel-eslint`](https://github.com/babel/babel-eslint) in your FOLIO project.
+```
+yarn add babel-eslint -D
+```
+
+In `.eslintrc`, specify your parser:
+```
+{
+  "extends": "stripes",
+  "parser": "babel-eslint"
+}
+```
+
+## Usage
+Run `eslint src` in your terminal to lint the files in the `src` directory (or modify to wherever the primary source of your project lives).
+
+### Recommended
+Add to your `package.json` `scripts`, so you can simply run `yarn lint`:
+```
+"lint": "eslint src"
+```
+
+## Additional information
+
+See project [STRIPES](https://issues.folio.org/projects/STRIPES) at the [FOLIO issue tracker](http://dev.folio.org/community/guide-issues).
+
+Other FOLIO Developer documentation is at [dev.folio.org](http://dev.folio.org/).

--- a/index.js
+++ b/index.js
@@ -1,3 +1,48 @@
 module.exports = {
-  extends: "eslint:recommended"
+  "extends": "airbnb",
+  "settings": {
+    "import/resolver": {
+      "webpack": {}
+    },
+    "react": {
+      "version": "15.6.1"
+    },
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+  },
+  "rules": {
+    "import/extensions": ["warn", "never"],
+    "jsx-a11y/href-no-hash": "off",
+    "jsx-a11y/label-has-for": "off",
+    "jsx-a11y/no-noninteractive-tabindex": ["error", {
+      "tags": [],
+      "roles": ["tabpanel", "dialog"],
+    }],
+    "max-len": "off",
+    "no-console": "off",
+    "no-param-reassign": ["error", {
+      "props": false
+    }],
+    "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
+    "no-underscore-dangle": "off",
+    "no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_"
+    }],
+    "react/forbid-prop-types": ["warn", {
+      "forbid": ["any", "array"]
+    }],
+    "react/jsx-filename-extension": "off",
+    "react/no-array-index-key": "off",
+    "react/require-default-props": "off",
+    "react/sort-comp": ["warn", {
+      "order": [
+        "static-methods",
+        "lifecycle",
+        "everything-else",
+        "render"
+      ]
+    }],
+  }
 };

--- a/package.json
+++ b/package.json
@@ -6,8 +6,19 @@
   "repository": "https://github.com/folio-org/eslint-config-stripes",
   "author": "Charles Lowell <cowboyd@frontside.io>",
   "license": "Apache 2.0",
-  "keywords": ["eslint", "eslintconfig"],
+  "keywords": [
+    "eslint",
+    "eslintconfig"
+  ],
   "peerDependencies": {
-    "eslint": ">= 3"
+    "eslint": "^4.7.2"
+  },
+  "dependencies": {
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-import-resolver-webpack": "^0.8.3",
+    "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.3.0"
   }
 }


### PR DESCRIPTION
Sets the existing ruleset of `stripes-components` as the new baseline for `eslint-config-stripes`.