### PR TITLE
Turn off a few default rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   "rules": {
     "import/extensions": ["warn", "never"],
-    "jsx-a11y/href-no-hash": "off",
+    "jsx-a11y/href-no-hash": "off", // deprecated rule
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/no-noninteractive-tabindex": ["error", {
       "tags": [],
@@ -22,9 +22,12 @@ module.exports = {
     }],
     "max-len": "off",
     "no-console": "off",
+    "no-else-return": "off",
+    "no-nested-ternary": "off",
     "no-param-reassign": ["error", {
       "props": false
     }],
+    "no-plusplus": "off",
     "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
     "no-underscore-dangle": "off",
     "no-unused-vars": ["warn", {


### PR DESCRIPTION
Based on conversation here: https://github.com/folio-org/stripes-core/pull/42

These few rules felt overly restrictive:
- `no-else-return`: the explicit `else` `return` can be much easier to read and parse as a human, even if it's a tiny bit more code for a machine
- `no-nested-ternary`: having it on forces jsx logic to be simpler, but can be very unwieldy
- `no-plusplus`: ++