### PR TITLE
Don't prefer const.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "prefer-const": "off",
     "import/extensions": ["warn", "never"],
     "jsx-a11y/href-no-hash": "off", // deprecated rule
     "jsx-a11y/label-has-for": "off",


### PR DESCRIPTION
`const` speaks to the JavaScript compiler, `let` to humans. This allows developers to optimize for readability and meaning.

See https://github.com/cowboyd/eslint-plugin-prefer-let for an in-depth discussion (although this PR stops short of mandating `let` for true variables)