### PR TITLE
Disable the rule "react/jsx-wrap-multilines"

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = {
       "forbid": ["any", "array"]
     }],
     "react/jsx-filename-extension": "off",
+    "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
     "react/require-default-props": "off",
     "react/sort-comp": ["warn", {


### PR DESCRIPTION
Following this rule introduces syntactic clutter that does not always improve, and sometimes impedes, clarity.

For example, I just moved the `<SearchAndSort>` component from ui-users (which still has its own ESLint config) to stripes-smart-components (which uses eslint-config-stripes) and found that I was getting new warnings about constructions like:

    <Route
      path={`${this.props.match.path}/view/:id`}
      render={props => <this.connectedNotes
        stripes={stripes}
        onToggle={this.toggleNotes}
        link={`${this.props.moduleName}/${props.match.params.id}`}
        {...props}
      />}
    />

Clarity would not be improved by surrounding the `<this.connectedNotes>` invocation with redundant parentheses.
