### PR TITLE
Throw warning for console statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
       "roles": ["tabpanel", "dialog"],
     }],
     "max-len": "off",
-    "no-console": "off",
+    "no-console": "warn",
     "no-else-return": "off",
     "no-nested-ternary": "off",
     "no-param-reassign": ["error", {


### PR DESCRIPTION
## Purpose
`console.log()` statements were being allowed by `eslint-config-stripes`, causing tedious follow-up work like https://github.com/folio-org/stripes-core/pull/160#issuecomment-359026041

## Approach
This won't cause linting to throw an error... yet. I recommend leaving it as a warning for a while to give `folio-org` developers a few months to clean up the warnings that will result. After those are minimized, we can tune this up to error.