### PR TITLE
Turn off errors for importing peer dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = {
   },
   "rules": {
     "import/extensions": ["warn", "never"],
+    "import/no-extraneous-dependencies": ["error", {
+      "peerDependencies": true
+    }],
     "jsx-a11y/href-no-hash": "off", // deprecated rule
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/label-has-for": [ "error", {


### PR DESCRIPTION
Now that React and ReactDOM have moved to being listed as peer dependencies in all projects (save for stripes-core) we should turn off this error.