### PR TITLE
Turn off some newline rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     "node": true,
   },
   "rules": {
-    "function-paren-newline": "off",
+    "function-paren-newline": ["error", "consistent"],
     "import/extensions": ["warn", "never"],
     "import/no-extraneous-dependencies": ["error", {
       "peerDependencies": true
@@ -43,15 +43,15 @@ module.exports = {
     "no-unused-vars": ["warn", {
       "argsIgnorePattern": "^_"
     }],
-    "object-curly-newline": "off",
+    "object-curly-newline": ["error", { "consistent": true }],
     "prefer-destructuring": "off",
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]
     }],
-    "react/jsx-closing-tag-location": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
+    "react/prefer-stateless-function": "off",
     "react/require-default-props": "off",
     "react/sort-comp": ["warn", {
       "order": [

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "function-paren-newline": "off",
     "import/extensions": ["warn", "never"],
     "import/no-extraneous-dependencies": ["error", {
       "peerDependencies": true
@@ -42,9 +43,12 @@ module.exports = {
     "no-unused-vars": ["warn", {
       "argsIgnorePattern": "^_"
     }],
+    "object-curly-newline": "off",
+    "prefer-destructuring": "off",
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]
     }],
+    "react/jsx-closing-tag-location": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",


### PR DESCRIPTION
For reference, here are the rules pages:
https://eslint.org/docs/rules/function-paren-newline
https://eslint.org/docs/rules/object-curly-newline
https://eslint.org/docs/rules/prefer-destructuring
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md

Basically, we've got a lot of code that violates these rules and I'm not 100% sold on having them turned on anyway. 

Personally, I actually prefer to write my code following these rules but I _do_ find that having it enforced is slightly paternalistic. If we want to keep them on, I'm all ears.