### PR TITLE
Change license metadata from "Apache 2.0" to "Apache-2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
   "author": "Charles Lowell <cowboyd@frontside.io>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "keywords": [
     "eslint",
     "eslintconfig"


### PR DESCRIPTION
This conforms to the SPDX standard expression of this licence:
https://spdx.org/licenses/Apache-2.0.html