### PR TITLE
update eslint-plugin-jsx-a11y dep to ^6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.6.0"
   }
 }


### PR DESCRIPTION
Versions prior to 6.0.3 emit the following warning in stripes-components:

```
/Users/mike/git/folio/stripes/stripes-components/lib/MultiColumnList/MCLRenderer.js
 584:11  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
/Users/mike/git/folio/stripes/stripes-components/lib/NavList/NavList.js
  31:9  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
```

on elements with `role="presentation"`, which should be ignored.

Fixes [STRIPES-511](https://issues.folio.org/browse/STRIPES-511)