### PR TITLE
Modify jsx-a11y/label-has-for

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/label-has-for": [ "error", {
       "required": {
-          "every": [ "id" ]
+        "some": [ "nesting", "id" ]
       },
       "allowChildren": false,
     }],


### PR DESCRIPTION
Allows either of the two styles:

1. Nesting:

	<label>
	  text
	  <control />
	</label>

2. ID-reference:

	<label htmlFor="foo">text</label>
	<control id="foo" />

Rather than requiring both nesting _and_ ID-reference:

	<label htmlFor="foo">
	  text
	  <control id="foo" />
	</label>