### PR TITLE
Use "consistent" configuration for the "quote-props" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
     }],
     "object-curly-newline": ["error", { "consistent": true }],
     "prefer-destructuring": "off",
+    "quote-props": ["error", "consistent"],
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]
     }],


### PR DESCRIPTION
I'm linting this code:
```
        headers: {
          'Accept': 'application/json',
          'Content-Type': 'application/json',
          'X-Okapi-Tenant': request.get('X-Okapi-Tenant'),
          'X-Okapi-Token': request.get('X-Okapi-Token')
        }
```
ESLint, with the present "quote-props" configuration, wants me to remove the quoting around the key "Accept"; but it seems pretty obvious to me that the code is clearer and more consistent if it's quoted in the same way as the other keys in the same object.