### PR TITLE
Reconfigure comma-dangle to use "only-multiline" everywhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,16 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "only-multiline",
+        "exports": "only-multiline",
+        "functions": "only-multiline"
+      }
+    ],
     "function-paren-newline": ["error", "consistent"],
     "import/extensions": ["warn", "never"],
     "import/no-extraneous-dependencies": ["error", {


### PR DESCRIPTION
Rationale: I am linting this code:
```
  {
    schema,
    context: {
      query: request.body,
      okapi: {
        url: request.get('X-Okapi-Url'),
        headers: {
          'Accept': 'application/json',
          'Content-Type': 'application/json',
          'X-Okapi-Tenant': request.get('X-Okapi-Tenant'),
          'X-Okapi-Token': request.get('X-Okapi-Token')
        }
      }
    }
  }
```
ESLint wants me to put commas on the end of all the last five lines but the very last:
```
          'X-Okapi-Token': request.get('X-Okapi-Token'),
        },
      },
    },
  }
```
This is simply wrong. No-one ever writes code like that except when they are doing it to satisfy an ESLint rule. The usual rationale for a dangling comma -- that it makes it easier to add and remove individual entries -- is nonsensical in such a situation.

The reconfiguration provided by this pull-request allows but does not require that a comma follows the last item in a group when the closing bracket is on the next line, but prohibits it when the bracket is on the same line. So these are good:
```
[
  1,
  2
]

[
  1,
  2,
]

[1, 2]
```
but this is not:
```
[1, 2,]
```
That seems right to me. I can't imagine anyone wanting to use the last of these, but the other three all make sense in different contexts.