### PR TITLE
Do not prefer template

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,16 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "only-multiline",
+        "exports": "only-multiline",
+        "functions": "only-multiline"
+      }
+    ],
     "function-paren-newline": ["error", "consistent"],
     "import/extensions": ["warn", "never"],
     "import/no-extraneous-dependencies": ["error", {

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ module.exports = {
     }],
     "object-curly-newline": ["error", { "consistent": true }],
     "prefer-destructuring": "off",
+    "prefer-template": "off",
     "quote-props": ["error", "consistent"],
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]


### PR DESCRIPTION
Once again, this arises from ESLint's desire to make me rewrite perfectly good code in a way that makes it worse. In this case:
```
`${okapi.url}/users` + (cql ? `?query=${cql}` : '')
```
which it wants me to replace with
```
`${okapi.url}/users{cql ? `?query=${cql}` : ''}`
```

Sometimes templates are a better way to express an idea than concatenation; sometimes concatenation expresses it more cleanly. How can a machine determine which cases fall into each category? It can't -- or, at least, ESLint can't. Programmers can, so we should use those instead.