### PR TITLE
Turn off the "arrow-parens" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "arrow-parens": "off",
     "comma-dangle": [
       "error",
       {


### PR DESCRIPTION
[This rule](https://eslint.org/docs/rules/arrow-parens) seems to be motivated primarily by the extremely unlikely scenario of accidentally typing `if (a => b)` when you mean `if (a >= b)` -- something that I doubt has _ever_ happened. To help avoid this non-issue, it makes all sorts of weird and arbitrary demands about when the parameters to an arrow function should and should not be parenthesised, based on some combination of how many parameters there are and whether the body is an expression to be yielded or a block to be executed.

One irritating thing about this rule is how you end up changing everything when you change anything. I might have a nice simple arrow function
```
foo => (foo * 2)
```
Then I decide I want to see logging:
```
foo => { console.log(`doubling ${foo}`); return foo * 2; }
```
But no -- now I arbitrarily have to parenthesize my argument:
```
(foo) => { console.log(`doubling ${foo}`); return foo * 2; }
```
No more! Throw off the shackles, brothers and sisters!