### PR TITLE
Turn off "arrow-body-style" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     "node": true,
   },
   "rules": {
+    "arrow-body-style": "off",
     "comma-dangle": [
       "error",
       {


### PR DESCRIPTION
Much the same arguments as for [turning off `arrow-parens`](https://github.com/folio-org/eslint-config-stripes/pull/24). Under the present regimen, if I have code like:
```
        somePromise.then(json => {
          console.log('extracting from', json);
          return json.users;
        });
```
then when I remove the logging, ESLint won't let me just delete the line I no longer need, but tells me to change it to:
```
        somePromise.then(json => json.users);
```
I think that's a call for me to make, not a program.