### PR TITLE
Turned off class-methods-use-this

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
   "rules": {
     "arrow-body-style": "off",
     "arrow-parens": "off",
+    "class-methods-use-this": "off",
     "comma-dangle": [
       "error",
       {


### PR DESCRIPTION
- Sometimes a renderer or function is appropriate only to a given React component.
- Sometimes that component is class based.
- Sometimes all other functions use `this` so are class methods already.
- Splitting out a single function in those cases looks really ugly and in the future, can lead to unnecessary refactoring and uneasily parsed diffs.