### PR TITLE
Pin eslint-plugin-react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -19,6 +19,6 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.6.0"
+    "eslint-plugin-react": "7.9.1"
   }
 }


### PR DESCRIPTION
## Purpose
`eslint-plugin-react` has been making frequent ruleset changes without major version bumps. We want to be more deliberate about rule changes, so we stop getting surprised by changes like this: https://github.com/folio-org/stripes-smart-components/pull/184

## Approach
Pin `eslint-plugin-react`'s version to prevent future surprise changes. This also includes a major version bump to `eslint-config-stripes`.