### PR TITLE
Allow any key spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change history for eslint-config-stripes
+
+## 2.1.0 (IN PROGRESS)
+
+* Turn off [the `key-spacing` rule](https://eslint.org/docs/rules/key-spacing). Available from v2.0.1.
+
+## [2.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v2.0.0) (2018-06-04)
+[Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v1.1.1...v2.0.0)
+
+* First version to pin a specific version of the `eslint-config-airbnb` dependency, to avoid nasty surprises where the rules change on their own.
+

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = {
                                       focus transitions serve as a primary indicator of a change in page context as new
                                       trees of components mount/dismount.
                                       */  
+    "key-spacing": "off",
     "linebreak-style": "off",
     "max-len": "off",
     "no-console": "warn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
This rule complains about perfectly cromulent code such as:

    res.push({
      base:      jsonSchema['folio:linkBase'],
      fromField: jsonSchema['folio:linkFromField'],
      toField:   jsonSchema['folio:linkToField'],
      include:   jsonSchema['folio:includedElement'],
    });

I've looked through all the configuration options described at https://eslint.org/docs/rules/key-spacing and it seems there is no sufficiently flexible way to configure this that will allow all reasonable ways of laying out an object literal. So I think the best thing is just to turn it off.
