### PR TITLE
Add an exception for stripes-config in import/no-unresolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     "import/no-extraneous-dependencies": ["error", {
       "peerDependencies": true
     }],
-    "import/no-unresolved": ["error", { "ignore": ["react", "react-dom"] } ],
+    "import/no-unresolved": ["error", { "ignore": ["react", "react-dom", "stripes-config"] } ],
     "jsx-a11y/anchor-is-valid": ["error", {
       "components": ["Link"],
       "specialLink": ["to"]
@@ -53,7 +53,7 @@ module.exports = {
                                       users of Assistive Technology or those who just prefer to navigate using a keyboard alone -
                                       focus transitions serve as a primary indicator of a change in page context as new
                                       trees of components mount/dismount.
-                                      */  
+                                      */
     "key-spacing": "off",
     "linebreak-style": "off",
     "max-len": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
We've got a lot of `// eslint-disable-line` on `import`s of this package and I noticed that doing so has prevented lint from showing other errors about that line.

This will allow us to remove those disables.