### PR TITLE
Pin all ruleset dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -14,11 +14,11 @@
     "eslint": "^4.8.0"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-import-resolver-webpack": "^0.8.3",
-    "eslint-plugin-babel": "^4.1.2",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-config-airbnb": "16.1.0",
+    "eslint-import-resolver-webpack": "0.8.3",
+    "eslint-plugin-babel": "4.1.2",
+    "eslint-plugin-import": "2.8.0",
+    "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react": "7.9.1"
   }
 }


### PR DESCRIPTION
`eslint-plugin-jsx-a11y` released a new minor version with rule changes (see https://github.com/folio-org/stripes-components/pull/478#issuecomment-402658404)

To prevent surprise rule changes for FOLIO developers, we can use the same approach we took in https://github.com/folio-org/eslint-config-stripes/pull/30, but this time pin _everything_.

I'll make a follow-up PR that updates all the ruleset dependencies to their latest versions and bumps `eslint-config-stripes` to `3.0.0`.