### PR TITLE
Modify class member and operator linebreak rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = {
                                       */
     "key-spacing": "off",
     "linebreak-style": "off",
+    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-len": "off",
     "no-console": "warn",
     "no-else-return": "off",
@@ -73,6 +74,7 @@ module.exports = {
       "argsIgnorePattern": "^_"
     }],
     "object-curly-newline": ["error", { "consistent": true }],
+    "operator-linebreak": ["off"],
     "prefer-destructuring": "off",
     "prefer-template": "off",
     "quote-props": ["error", "consistent"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
## Rule changes
- [`operator-linebreak`](https://eslint.org/docs/rules/operator-linebreak): completely off (see https://github.com/folio-org/stripes-components/pull/538 for conversation)
- [`lines-between-class-members`](https://eslint.org/docs/rules/lines-between-class-members): modified to make BigTest interactors more readable