### PR TITLE
Turn off react destructuring assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 3.2.0 (IN PROGRESS)
+
+* Turn off `react/destructuring-assignment` rule. Available from v3.1.1.
+
 ## [3.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v3.1.0) (2018-09-03)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.0.0...v3.1.0)
 

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ module.exports = {
     "prefer-destructuring": "off",
     "prefer-template": "off",
     "quote-props": ["error", "consistent"],
+    "react/destructuring-assignment": ["off"],
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]
     }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
Turn off react/destructuring-assignment

This rule bureaucratically enforces a style that in some circumstances
is clear and in others is decided not. For exmaple, in order to
satisfy it in https://github.com/folio-org/ui-myprofile/pull/15/files,
poor @VictorSoroka1 changed the perfectly clear code

	paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-myprofile.settings.index.paneTitle' })}

to

	const { stripes: { intl } } = this.props;
	// ...
	paneTitle={intl.formatMessage({ id: 'ui-myprofile.settings.index.paneTitle' })}

This is a classic case of a rule that tries to impose a mindless
consistency at the expense of the individual programmer's taste,
experience and judgement.