### PR TITLE
Move webpack to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 3.3.0 (IN PROGRESS)
+
+* Set `webpack` as a dependency
+
 ## [3.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v3.2.0) (2018-09-12)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.1.0...v3.2.0)
 * Turn off `react/destructuring-assignment` rule.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "eslint": "^5.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
-    "webpack": "^4.16.5"
+    "eslint": "^5.3.0"
   },
   "dependencies": {
     "eslint-config-airbnb": "17.1.0",
@@ -22,6 +21,7 @@
     "eslint-plugin-babel": "5.1.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-react": "7.11.0"
+    "eslint-plugin-react": "7.11.0",
+    "webpack": "^4.0.0"
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/folio-org/ui-developer/pull/21

`webpack` can be satisfied as a `peerDependency` of `eslint-import-resolver-webpack` by delivering it as a dependency of `eslint-config-stripes`.

This means Stripes UI modules don't have to add `webpack` to `devDependencies`.

Proof-of-concept: https://github.com/folio-org/ui-eholdings/pull/559