### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change history for eslint-config-stripes
 
+## [4.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v4.0.0) (2019-01-17)
+[Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.2.1...v4.0.0)
+
+* Upgrade `eslint-plugin-babel` https://github.com/babel/eslint-plugin-babel/compare/v5.1.0...v5.3.0
+* Upgrade `eslint-plugin-jsx-a11y` https://github.com/evcohen/eslint-plugin-jsx-a11y/compare/v6.1.1...v6.1.2
+* Upgrade `eslint-plugin-react` https://github.com/yannickcr/eslint-plugin-react/compare/v7.11.0...v7.12.4
+
 ## [3.2.1](https://github.com/folio-org/eslint-config-stripes/tree/v3.2.1) (2018-09-14)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.2.0...v3.2.1)
 

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
     "eslint": "^5.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.3.0"
+    "eslint": "^5.12.0"
   },
   "dependencies": {
     "eslint-config-airbnb": "17.1.0",
     "eslint-import-resolver-webpack": "0.10.1",
-    "eslint-plugin-babel": "5.1.0",
+    "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-react": "7.11.0",
+    "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-react": "7.12.4",
     "webpack": "^4.0.0"
   }
 }


### PR DESCRIPTION
It's been a while since we pulled in upstream ruleset changes (primarily from the fast-moving `eslint-plugin-react`).

* Upgrade `eslint-plugin-babel` https://github.com/babel/eslint-plugin-babel/compare/v5.1.0...v5.3.0
* Upgrade `eslint-plugin-jsx-a11y` https://github.com/evcohen/eslint-plugin-jsx-a11y/compare/v6.1.1...v6.1.2
* Upgrade `eslint-plugin-react` https://github.com/yannickcr/eslint-plugin-react/compare/v7.11.0...v7.12.4