### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for eslint-config-stripes
 
+## [4.0.1](https://github.com/folio-org/eslint-config-stripes/tree/v4.0.1) (2019-01-23)
+[Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v4.0.0...v4.0.1)
+
+* Fix `package.json` version mismatch
+
 ## [4.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v4.0.0) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.2.1...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "3.2.1",
+  "version": "4.0.1",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
I forgot to bump the `package.json` version number in https://github.com/folio-org/eslint-config-stripes/pull/41 🤦‍♂️ 

Jenkins caught it when I tried to publish the `v4.0.0` tag with "Git release tag and NPM version mismatch".