### PR TITLE
ESCONF-2: Add eslint rules for react hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for eslint-config-stripes
 
+## [4.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v4.1.0) (2019-01-03)
+* Add eslint [rules](https://reactjs.org/docs/hooks-rules.html) for react hooks (ESCONF-2)
+
 ## [4.0.1](https://github.com/folio-org/eslint-config-stripes/tree/v4.0.1) (2019-01-23)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v4.0.0...v4.0.1)
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     "browser": true,
     "node": true,
   },
+  "plugins": ["react-hooks"],
   "rules": {
     "arrow-body-style": "off",
     "arrow-parens": "off",
@@ -37,7 +38,6 @@ module.exports = {
       "specialLink": ["to"]
     }],
     "jsx-a11y/href-no-hash": "off", // deprecated rule
-    "jsx-a11y/label-has-for": "off",
     "jsx-a11y/label-has-for": [ "error", {
       "required": {
         "some": [ "nesting", "id" ]
@@ -95,6 +95,8 @@ module.exports = {
         "render"
       ]
     }],
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -22,6 +22,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "webpack": "^4.0.0"
   }
 }


### PR DESCRIPTION
Since React 16.8 supports hooks, there are some practices which need to be followed and there are few eslint [rules](https://reactjs.org/docs/hooks-rules.html) for that.
