### PR TITLE
Turn off quote-props rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for eslint-config-stripes
 
+## 5.1.0 - IN PROGRESS
+* Turn off `quote-props` rule.
+
 ## [5.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.0.0) (2019-10-23)
 * Undo revert of Security update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Releasing as a major version update. Part of STRIPES-648.
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = {
     "operator-linebreak": ["off"],
     "prefer-destructuring": "off",
     "prefer-template": "off",
-    "quote-props": ["error", "consistent"],
+    "quote-props": "off",
     "react/destructuring-assignment": ["off"],
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]


### PR DESCRIPTION
It does what the label says.

[Here's the rule.](https://eslint.org/docs/rules/quote-props)

Essentially, what it means is that if we want to have an object like
```
const sharedProps = {
  'aria-label': 'A label',
  id: 'an-id,
  foo: 'bar',
}
```
we need to put quotes arounds `id`, `foo`, and any other property names for the sake of consistency with the quoted `aria-label` prop name (which requires them because of the hyphen).

This is silly.