### PR TITLE
Turn off and `react/jsx-props-no-spreading` and `react/static-property-placement` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.1.0 - IN PROGRESS
 * Turn off `quote-props` rule.
+* Turn off and `react/jsx-props-no-spreading` and `react/static-property-placement` rules since they contradict patterns already well-established in our codebases.
 
 ## [5.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.0.0) (2019-10-23)
 * Undo revert of Security update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Releasing as a major version update. Part of STRIPES-648.

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ module.exports = {
       "forbid": ["any", "array"]
     }],
     "react/jsx-filename-extension": "off",
+    "react/jsx-props-no-spreading": "off",
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
     "react/prefer-stateless-function": "off",
@@ -96,6 +97,7 @@ module.exports = {
         "render"
       ]
     }],
+    "react/static-property-placement": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
   },


### PR DESCRIPTION
since they contradict patterns already well-established in our codebases.

Example violation of `react/jsx-props-no-spreading`:

```
render() {
    return (
      <MyComponent {...this.props} />
    );
  }
```

Example violation of `react/static-property-placement` (since it resides inside a class):

```
export default class GreetingModal extends React.Component {
  static propTypes = {
    open: PropTypes.bool,
    onClose: PropTypes.func,
  };
```

I noticed this first appearing after upgrading `eslint` to 6.2.1.