### PR TITLE
Stripes 648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.0 - IN PROGRESS
 * Turn off `quote-props` rule.
 * Turn off and `react/jsx-props-no-spreading` and `react/static-property-placement` rules since they contradict patterns already well-established in our codebases.
+* Establish order for `static-variables` to appear after `static-methods` but before everything else to match our current style since it is now acknowledged by https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md.
 
 ## [5.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.0.0) (2019-10-23)
 * Undo revert of Security update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Releasing as a major version update. Part of STRIPES-648.

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ module.exports = {
     "react/sort-comp": ["warn", {
       "order": [
         "static-methods",
+        "static-variables",
         "lifecycle",
         "everything-else",
         "render"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
Establish order for `static-variables` to appear after `static-methods` but before everything else to match our current style since it is now acknowledged by https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md.