### PR TITLE
Global overrides for eslint 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## [5.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.2.0) (2020-02-18)
+* Turn off and `react/jsx-curly-newline` and `react/state-in-constructor` rules since they contradict patterns already well-established in our codebases.
+* Turn off `max-classes-per-file` rule for test files since it is perfectly acceptable and common to have multiple classes in a single test file (for example: interactor files).
+
 ## [5.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.1.0) (2020-01-31)
 * Turn off `quote-props` rule.
 * Turn off and `react/jsx-props-no-spreading` and `react/static-property-placement` rules since they contradict patterns already well-established in our codebases.

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ module.exports = {
     "react/forbid-prop-types": ["warn", {
       "forbid": ["any", "array"]
     }],
+    "react/jsx-curly-newline": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-props-no-spreading": "off",
     "react/jsx-wrap-multilines": "off",
@@ -98,6 +99,7 @@ module.exports = {
         "render"
       ]
     }],
+    "react/state-in-constructor": "off",
     "react/static-property-placement": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -106,6 +108,7 @@ module.exports = {
     {
       files: ["**/test/**"],
       rules: {
+        "max-classes-per-file": "off",
         "no-console": "off",
         // lexically bound "this" prevents access to the Mocha test context.
         // See https://mochajs.org/#arrow-functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
- Ignoring rules that eslint 6 introduced which are accepted practice in FOLIO.