### PR TITLE
Turn on `react/jsx-sort-props` with warning on `callbacksLast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for eslint-config-stripes
 
+## (IN PROGRESS)
+* Turn on `react/jsx-sort-props` with warning on `callbacksLast` - callbacks must be listed after all other props
+
 ## [5.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.2.0) (2020-02-18)
 * Turn off and `react/jsx-curly-newline` and `react/state-in-constructor` rules since they contradict patterns already well-established in our codebases.
 * Turn off `max-classes-per-file` rule for test files since it is perfectly acceptable and common to have multiple classes in a single test file (for example: interactor files).

--- a/index.js
+++ b/index.js
@@ -86,6 +86,16 @@ module.exports = {
     "react/jsx-curly-newline": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/jsx-sort-props": [
+      1,
+      {
+        noSortAlphabetically: true,
+        ignoreCase: true,
+        callbacksLast: true,
+        shorthandLast: false,
+        reservedFirst: false,
+      },
+    ],
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
     "react/prefer-stateless-function": "off",


### PR DESCRIPTION
docs - https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md#callbackslast
context, where it's started https://github.com/folio-org/ui-inventory/pull/998#discussion_r411480371
link to the discussion in slack - https://folio-project.slack.com/archives/C210UCHQ9/p1587461296346600