### PR TITLE
Turn off `react/jsx-one-expression-per-line`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 5.3.0
+
+Turn off `react/jsx-one-expression-per-line` so we can avoid `{' '}` which is just silly.
+
 ## [5.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.2.0) (2020-02-18)
 * Turn off and `react/jsx-curly-newline` and `react/state-in-constructor` rules since they contradict patterns already well-established in our codebases.
 * Turn off `max-classes-per-file` rule for test files since it is perfectly acceptable and common to have multiple classes in a single test file (for example: interactor files).

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ module.exports = {
     }],
     "react/jsx-curly-newline": "off",
     "react/jsx-filename-extension": "off",
+    "react/jsx-one-expression-per-line": "off",
     "react/jsx-props-no-spreading": "off",
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",


### PR DESCRIPTION
This lets us avoid `{' '}` which is just silly. There is simply no way
```
<div>
  blah blah 
  {' '}
  {foo}
</div>
```
is superior to
```
<div>blah blah {foo}</div>
```