### PR TITLE
Turn off camelcase for UNSAFE_ methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
   "rules": {
     "arrow-body-style": "off",
     "arrow-parens": "off",
+    "camelcase": ["error", { allow: ["^UNSAFE_"] }],
     "class-methods-use-this": "off",
     "comma-dangle": [
       "error",


### PR DESCRIPTION
Does what it says on the tin.

https://eslint.org/docs/rules/camelcase#allow