### PR TITLE
Ensure minimist is at least v1.2.3 in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "^2.1.2",
     "webpack": "^4.41.2"
+  },
+  "resolutions": {
+    "minimist": "^1.2.3"
   }
 }


### PR DESCRIPTION
because of prototype pollution security issue. See here for more info: https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764