### PR TITLE
STRIPES-711 update deps to avoid errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 5.3.0
 
-Turn off `react/jsx-one-expression-per-line` so we can avoid `{' '}` which is just silly.
+* Turn off `react/jsx-one-expression-per-line` so we can avoid `{' '}` which is just silly.
+* Update `elinst-plugin-import` to `2.22.1` to avoid barfing on `∞` somewhere in a transitive dependency.
 
 ## [5.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.2.0) (2020-02-18)
 * Turn off and `react/jsx-curly-newline` and `react/state-in-constructor` rules since they contradict patterns already well-established in our codebases.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-config-airbnb": "18.0.1",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-babel": "5.3.0",
-    "eslint-plugin-import": "2.18.2",
+    "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.16.0",


### PR DESCRIPTION
Somewhere in a transitive dependency, somebody thought it would be super
cool to use `∞` instead of `Infinity` without correctly updating their
peer-deps. This support wasn't introduced in `eslint-plugin-import`
until at least `v2.22.1`, so we need that.

Refs [STRIPES-711](https://issues.folio.org/browse/STRIPES-711)