### PR TITLE
add Acquisitions-UI config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## [5.4.0](#) (UNRELEASED)
+
+* add Acquisitions-UI config
+
 ## [5.3.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.3.0) (2020-12-09)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.2.0...v5.3.0)
 

--- a/acquisitions.js
+++ b/acquisitions.js
@@ -1,0 +1,137 @@
+module.exports = {
+  'extends': './index',
+  'parser': 'babel-eslint',
+  'plugins': [
+    'babel',
+    'filenames',
+    'jest',
+  ],
+  'env': {
+    'jest/globals': true,
+  },
+  'rules': {
+    'import/prefer-default-export': 'off',
+    'filenames/match-exported': 'error',
+    'key-spacing': [
+      'error',
+      {
+        'beforeColon': false,
+        'afterColon': true,
+      },
+    ],
+    'padding-line-between-statements': [
+      'error',
+      {
+        'blankLine': 'always',
+        'prev': '*',
+        'next': 'return',
+      },
+      {
+        'blankLine': 'always',
+        'prev': [
+          'const',
+          'let',
+          'var',
+        ],
+        'next': '*',
+      },
+      {
+        'blankLine': 'any',
+        'prev': [
+          'const',
+          'let',
+          'var',
+        ],
+        'next': [
+          'const',
+          'let',
+          'var',
+        ],
+      },
+    ],
+    'react/jsx-one-expression-per-line': 0,
+    'comma-dangle': [
+      'error',
+      {
+        'arrays': 'always-multiline',
+        'objects': 'always-multiline',
+        'imports': 'always-multiline',
+        'exports': 'always-multiline',
+        'functions': 'always-multiline',
+      },
+    ],
+    'max-len': [
+      'error',
+      {
+        'code': 120,
+        'ignoreComments': true,
+        'ignoreTrailingComments': true,
+        'ignoreUrls': true,
+        'ignoreStrings': true,
+        'ignoreTemplateLiterals': true,
+        'ignoreRegExpLiterals': true,
+      },
+    ],
+    'react/jsx-closing-bracket-location': [
+      'error',
+      'tag-aligned',
+    ],
+    'react/jsx-closing-tag-location': [
+      'error',
+      'tag-aligned',
+    ],
+    'no-this-before-super': 'error',
+    'prefer-object-spread': 'error',
+    'jsx-quotes': [
+      'error',
+      'prefer-double',
+    ],
+    'prefer-const': 'error',
+    'react/jsx-curly-spacing': [
+      'error',
+      {
+        'when': 'never',
+        'children': true,
+      },
+    ],
+    'eol-last': [
+      'error',
+      'always',
+    ],
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        'max': 1,
+        'maxEOF': 0,
+        'maxBOF': 0,
+      },
+    ],
+    'no-array-constructor': 'error',
+    'no-loop-func': 'error',
+    'no-new-func': 'error',
+    'max-lines': [
+      'error',
+      1000,
+    ],
+    'max-depth': [
+      'error',
+      3,
+    ],
+    'no-constant-condition': 'error',
+    'react/state-in-constructor': 'off',
+    'react/jsx-fragments': 'off',
+    'react/jsx-props-no-spreading': 'off',
+  },
+  'overrides': [
+    {
+      'files': [ 'test/bigtest/**/*' ],
+      'rules': {
+        'filenames/match-exported': 'off',
+        'func-names': 'off',
+        'no-unused-expressions': 'off',
+        'max-len': 'off',
+        'one-var': 'off',
+      }
+    }
+  ]
+};


### PR DESCRIPTION
to enable import of shared config using stripes workspace (`"extends": ["@folio/eslint-config-stripes/acquisitions"]`)