### PR TITLE
Turned off no-await-in-loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ module.exports = {
     "linebreak-style": "off",
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-len": "off",
+    "no-await-in-loop": "off",
     "no-console": "warn",
     "no-else-return": "off",
     "no-multiple-empty-lines": "off",


### PR DESCRIPTION
[I don't really see the point of this rule.](https://eslint.org/docs/rules/no-await-in-loop)

The only times I await in a for-loop is when I expressly want to wait for the first iteration before firing the second iteration. If I didn't care about waiting between iterations, I'd use `forEach` like a sane human being.