### PR TITLE
UIU-2068 omit no-return-await

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = {
     }],
     "no-plusplus": "off",
     "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
+    "no-return-await": "off",
     "no-underscore-dangle": "off",
     "no-unused-vars": ["warn", {
       "argsIgnorePattern": "^_"


### PR DESCRIPTION
This has got to be the stupidest rule ever. The
[documentation](https://eslint.org/docs/rules/no-return-await) states it
"aims to prevent a likely common performance hazard" caused by using
`await` inside an `async` function keeping "the current function in the
call stack until the Promise that is being awaited has resolved". But,
uh, ain't that _exactly the point of calling `await`_? #SMH