### PR TITLE
STRWEB-5: Turn off jsx-uses-react and react-in-jsx-scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## [5.5.0] IN PROGRESS
+
+* Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs STRWEB-5.
+
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)
 

--- a/index.js
+++ b/index.js
@@ -90,9 +90,11 @@ module.exports = {
     "react/jsx-filename-extension": "off",
     "react/jsx-one-expression-per-line": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/jsx-uses-react": "off",
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
     "react/prefer-stateless-function": "off",
+    "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",
     "react/sort-comp": ["warn", {
       "order": [
@@ -107,6 +109,7 @@ module.exports = {
     "react/static-property-placement": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
This PR turns off both `react/jsx-uses-react` and `react/react-in-jsx-scope` in order to comply with the new JSX plugin setup in:

https://github.com/folio-org/stripes-webpack/pull/11

More info:

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint