### PR TITLE
ESCONF-4: Turn off warnings about no-unused-vars for React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [5.5.0] IN PROGRESS
 
-* Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs STRWEB-5.
+* Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs ESCONF-4.
 
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ module.exports = {
     "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
     "no-underscore-dangle": "off",
     "no-unused-vars": ["warn", {
-      "argsIgnorePattern": "^_"
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "React"
     }],
     "object-curly-newline": ["error", { "consistent": true }],
     "operator-linebreak": ["off"],


### PR DESCRIPTION
This PR is related to the work done in:

https://github.com/folio-org/stripes-webpack/pull/11 and https://github.com/folio-org/eslint-config-stripes/pull/79

After setting it up the error:

`React is defined but never used no-unused-vars`

started showing up everywhere.

React created a tool to clean it up:

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports

But for now we can turn it off here.

