### PR TITLE
ESCONF-8 replace babel-eslint with @babel/eslint-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for eslint-config-stripes
 
-## [5.5.0] IN PROGRESS
+## [6.0.0] IN PROGRESS
 
 * Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs ESCONF-4.
+* Migrate from `babel-eslint` to `@babel/eslint-parser`. Refs ESCONF-8.
 
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { babelOptions } = require('@folio/stripes-webpack');
+
 module.exports = {
   "extends": "airbnb",
   "settings": {
@@ -123,5 +125,10 @@ module.exports = {
         "prefer-arrow-callback": "off",
       }
     }
-  ]
+  ],
+  parser: "@babel/eslint-parser",
+  parserOptions: {
+    requireConfigFile: false,
+    babelOptions,
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "5.5.0",
+  "version": "6.0.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -10,20 +10,22 @@
     "eslintconfig"
   ],
   "peerDependencies": {
-    "eslint": "^6.2.1"
+    "eslint": "^7.32.0"
   },
   "devDependencies": {
-    "eslint": "^6.2.1"
+    "eslint": "^7.32.0"
   },
   "dependencies": {
-    "eslint-config-airbnb": "18.0.1",
+    "@babel/eslint-parser": "^7.15.0",
+    "@folio/stripes-webpack": "^1.4.0",
+    "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-jsx-a11y": "6.2.3",
+    "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-no-only-tests": "^2.3.1",
-    "eslint-plugin-react": "7.16.0",
-    "eslint-plugin-react-hooks": "^2.1.2",
+    "eslint-plugin-react": "7.24.0",
+    "eslint-plugin-react-hooks": "4.2.0",
     "webpack": "^4.41.2"
   }
 }


### PR DESCRIPTION
Replace `babel-eslint` with `@babel/eslint-parser`, and upgrade many
related dependencies at the same time. `@babel/eslint-parser` needs
access to the babel options (or a link directly to the babel config
file) in order to handle parsing correctly; this is handled here by
importing the config directly from `@folio/stripes-webpack`.

Note: this is a major-version-upgrade due to bumping the eslint peer-dep to v7. It's _possible_ we could get away with supporting v6 or v7 here, but I don't think it's likely a good idea. And since we tend to lock to specific versions of of this module anyway, I don't think changing the major version, rather than the minor, will actually be a significantly different impact.

Refs [ESCONF-8](https://issues.folio.org/browse/ESCONF-8), [STRIPES-742](https://issues.folio.org/browse/STRIPES-742)