### PR TITLE
ESCONF-10 import babel options from stripes-webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs ESCONF-4.
 * Migrate from `babel-eslint` to `@babel/eslint-parser`. Refs ESCONF-8.
+* Migrate to `@folio/stripes-webpack` `v2`, which provides babel config options. Refs ESCONF-10.
 
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^1.4.0",
+    "@folio/stripes-webpack": "^2.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-babel": "5.3.0",


### PR DESCRIPTION
Really, this is ESCONF-8, but when that work was merged we didn't know
the next version of stripes-webpack would be a major version.

Refs [ESCONF-8](https://issues.folio.org/browse/ESCONF-8), [ESCONF-10](https://issues.folio.org/browse/ESCONF-10)