### PR TITLE
ESCONF-13: Upgrade stripes-webpack to v3 and webpack to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## [6.1.0] IN PROGRESS
+
+* Migrate to `@folio/stripes-webpack` `v3`. Refs ESCONF-13.
+
 ## [6.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.0.0) (2021-09-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.4.0...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^2.0.0",
+    "@folio/stripes-webpack": "^3.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-babel": "5.3.0",
@@ -26,6 +26,6 @@
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
-    "webpack": "^4.41.2"
+    "webpack": "^5.58.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/eslint-parser": "^7.15.0",
     "@folio/stripes-webpack": "^3.0.0",
     "eslint-config-airbnb": "18.2.1",
-    "eslint-import-resolver-webpack": "0.11.1",
+    "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsx-a11y": "6.4.1",


### PR DESCRIPTION
https://issues.folio.org/browse/ESCONF-13

There are 2 corresponding PRs related to this:

* stripes-webpack https://github.com/folio-org/stripes-webpack/pull/36
* stripes-cli https://github.com/folio-org/stripes-cli/pull/270

