### PR TITLE
ESCONF-13 use webpack v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 3.2.3 IN PROGRESS
+
+* Use webpack v5. Refs ESCONF-13.
+
 ## [3.2.2](https://github.com/folio-org/eslint-config-stripes/tree/v3.2.2) (2019-01-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v3.2.1...v3.2.2)
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-react": "7.11.0",
-    "webpack": "^4.0.0"
+    "webpack": "^5.0.0"
   }
 }


### PR DESCRIPTION
Upgrade to `webpack` `v5`. It would be so lovely if there were a way to
provide dev-peer-deps. Alas.

Refs [ESCONF-13](https://issues.folio.org/browse/ESCONF-13), [STRWEB-4](https://issues.folio.org/browse/STRWEB-4)