### PR TITLE
ESCONF-13 use webpack v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 4.3.2 IN PROGRESS
+
+* Upgrade to webpack v5. Refs ESCONF-13.
+
 ## [4.3.1](https://github.com/folio-org/eslint-config-stripes/tree/v4.3.1) (2019-10-17)
 * Reverting eslint update since version should be a major bump as it can break when used in workspaces with modules/platforms still referring to eslint 5.x.x. Part of STRIPES-648.
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "webpack": "^4.0.0"
+    "webpack": "^5.61.0"
   }
 }


### PR DESCRIPTION
Upgrade to `webpack` `v5`. It would be so lovely if there were a way to
provide dev-peer-deps. Alas.

Refs [ESCONF-13](https://issues.folio.org/browse/ESCONF-13), [STRWEB-4](https://issues.folio.org/browse/STRWEB-4)