### PR TITLE
ESCONF-13 use webpack v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 5.4.1 IN PROGRESS
+
+* Upgrade to webpack v5. Refs ESCONF-13.
+
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "^2.1.2",
-    "webpack": "^4.41.2"
+    "webpack": "^5.61.0"
   }
 }


### PR DESCRIPTION
Upgrade to `webpack` `v5`. It would be so lovely if there were a way to
provide dev-peer-deps. Alas.

Refs [ESCONF-13](https://issues.folio.org/browse/ESCONF-13), [STRWEB-4](https://issues.folio.org/browse/STRWEB-4)