### PR TITLE
Revert "ESCONF-13: Upgrade stripes-webpack to v3 and webpack to v5"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for eslint-config-stripes
 
-## [6.1.0] IN PROGRESS
-
-* Migrate to `@folio/stripes-webpack` `v3`. Refs ESCONF-13.
-
 ## [6.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.0.0) (2021-09-24)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.4.0...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "6.1.0",
+  "version": "6.0.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -17,15 +17,15 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^3.0.0",
+    "@folio/stripes-webpack": "^2.0.0",
     "eslint-config-airbnb": "18.2.1",
-    "eslint-import-resolver-webpack": "^0.13.1",
+    "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
-    "webpack": "^5.58.1"
+    "webpack": "^4.41.2"
   }
 }


### PR DESCRIPTION
Reverts folio-org/eslint-config-stripes#85

Rolling back to webpack v4 due to numerous/so-far-insurmountable BigTest config glitches.