### PR TITLE
Revert "revert to webpack v4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.5.0] IN PROGRESS
 
 * Turn off `react/jsx-uses-react` and `react/react-in-jsx-scope`. Refs ESCONF-4.
+* Upgrade to `webpack` `v5`. Refs ESCONF-13.
 
 ## [5.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v5.4.0) (2021-03-19)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v5.3.0...v5.4.0)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "^2.1.2",
-    "webpack": "^4.41.2"
+    "webpack": "^5.61.0"
   }
 }


### PR DESCRIPTION
webpack 5 is back, baby, back!

Reverts folio-org/eslint-config-stripes#92

