### PR TITLE
ESCONF-16 lock webpack to ~5.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 6.2.0 IN PROGRESS
+
+* Pin `webpack` to avoid conflicts with `karma-webpack` and `moment`. Refs ESCONF-16.
+
 ## [6.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.1.0) (2022-02-08)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.0.0...v6.1.0)
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
-    "webpack": "^5.58.1"
+    "webpack": "~5.68.0"
   }
 }


### PR DESCRIPTION
Recent `webpack` releases interact poorly with `moment` and
`karma-webpack`. While this isn't an issue here directly, the dependency
here does pull `webpack` into the build tree and if this version,
instead of `stripes-cli`'s, gets hoisted, then other modules can be
impacted by the loose constraint here.

Thus, here too we must lock `webpack` to `~5.68.0`. 😞 

Refs [ESCONF-16](https://issues.folio.org/browse/ESCONF-16), [STCLI-195](https://issues.folio.org/browse/STCLI-195)