### PR TITLE
ESCONF-18 bump stripes-webpack to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.2.0 IN PROGRESS
 
 * Pin `webpack` to avoid conflicts with `karma-webpack` and `moment`. Refs ESCONF-16.
+* Bump `@folio/stripes-webpack` to `v4` so it stays in sync with `@folio/stripes-cli`. Refs ESCONF-18.
 
 ## [6.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.1.0) (2022-02-08)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^3.0.0",
+    "@folio/stripes-webpack": "^4.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.0",


### PR DESCRIPTION
Bump `@folio/stripes-webpack` to `v4` to stay in sync with the version
provided by `@folio/stripes-cli`. This makes me feel
`@folio/stripes-webpack` ought to be a peer, rather than a direct dep,
but I think that would only work in NPM (where peers are installed)
but not in yarn (where peers are ignored). Hmmmmmm.

Refs [ESCONF-18](https://issues.folio.org/browse/ESCONF-18), [STCLI-203](https://issues.folio.org/browse/STCLI-203)