### PR TITLE
ESCONF-19: Add TypeScript linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,9 @@ module.exports = {
         // must disable the traditional rule
         // as it reports false positive on TS
         "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": ["error"]
+        "@typescript-eslint/no-use-before-define": ["error"],
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
       }
     },
     {

--- a/index.js
+++ b/index.js
@@ -138,6 +138,12 @@ module.exports = {
         "plugin:@typescript-eslint/recommended",
         "plugin:import/typescript",
       ],
+      "rules": {
+        // must disable the traditional rule
+        // as it reports false positive on TS
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-use-before-define": ["error"]
+      }
     },
     {
       files: ["**/*.d.ts"],

--- a/index.js
+++ b/index.js
@@ -123,8 +123,28 @@ module.exports = {
         // lexically bound "this" prevents access to the Mocha test context.
         // See https://mochajs.org/#arrow-functions
         "prefer-arrow-callback": "off",
-      }
-    }
+      },
+    },
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: "module",
+      },
+      plugins: ["@typescript-eslint"],
+      extends: [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:import/typescript",
+      ],
+    },
+    {
+      files: ["**/*.d.ts"],
+      rules: {
+        "react/no-unused-prop-types": "off",
+      },
+    },
   ],
   parser: "@babel/eslint-parser",
   parserOptions: {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@babel/eslint-parser": "^7.15.0",
     "@folio/stripes-webpack": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.28.0",
+    "@typescript-eslint/parser": "^5.28.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.0",


### PR DESCRIPTION
This PR adds linting rules for TypeScript.  This includes adding the TypeScript parser and eslint plugin to the dependencies, as this allows eslint to properly parse and understand TypeScript files.  Additionally, all recommended linting rules are added, such as `noExplicitAny`, disallowing the dangerous `any` wildcard type, among [many other rules](https://typescript-eslint.io/rules/).  There may be merit in some of the "strict" rules listed on that page, however, the recommended should be more than enough for 99% of cases, and the others are fairly opinionated.

For `.d.ts` files, which TypeScript uses as supplemental declaration-only files (cannot contain any real code), I had to disable the `react/no-unused-prop-types` flag.  Since these files contained stubbed declarations such as:

```ts
export interface FooProps {
  children: ReactNode;
  someOtherProp: string;
}
export class Foo extends Component<FooProps> {}
```

The props were declared, however, since the class contains no actual code, `eslint` flags this as an unused prop.  This fixes this false positive within these types of cases; actual class implementations should not be affected as they are not allowed within `.d.ts` files, only regular `.ts` or `.tsx` files.