### PR TITLE
ESCONF-21 update eslint-plugin versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 6.3.0 IN PROGRESS
+
+* Update eslint-plugins to current values. Refs ESCONF-21.
+
 ## [6.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.1.0...v6.2.0)
 

--- a/package.json
+++ b/package.json
@@ -16,16 +16,17 @@
     "eslint": "^7.32.0"
   },
   "dependencies": {
+    "@babel/core": "^7.18.13",
     "@babel/eslint-parser": "^7.15.0",
     "@folio/stripes-webpack": "^4.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "^0.13.1",
-    "eslint-plugin-babel": "5.3.0",
-    "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-no-only-tests": "^2.3.1",
-    "eslint-plugin-react": "7.24.0",
-    "eslint-plugin-react-hooks": "4.2.0",
+    "eslint-plugin-babel": "5.3.1",
+    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-jsx-a11y": "6.6.1",
+    "eslint-plugin-no-only-tests": "^3.0.0",
+    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react-hooks": "4.6.0",
     "webpack": "~5.68.0"
   }
 }


### PR DESCRIPTION
Update plugins to current versions to pickup features and bug-fixes,
e.g. recognizing state values in gDSFP as in-use.

The only major change here is to `no-only-tests` which has changed the
way block-scope matching works. We don't configure block-scope matching
so this is a non-issue for us.

Refs [ESCONF-21](https://issues.folio.org/browse/ESCONF-21)