### PR TITLE
ESCONF-20 loosen rules about tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for eslint-config-stripes
 
+## 6.3.0 IN PROGRESS
+
+* Loosen rules applied to tests and files recognized as tests. ESCONF-20.
+
 ## [6.2.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.1.0...v6.2.0)
 

--- a/index.js
+++ b/index.js
@@ -116,13 +116,23 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["**/test/**"],
+      files: ["**/test/**", "src/**/tests/*", "*.test.js"],
       rules: {
+        // tests may mock multiple classes for convenience; that's cool
         "max-classes-per-file": "off",
+
+        // sure, tests can write to the console
         "no-console": "off",
+
         // lexically bound "this" prevents access to the Mocha test context.
         // See https://mochajs.org/#arrow-functions
         "prefer-arrow-callback": "off",
+
+        // we do not care about proptypes in mocks
+        "react/prop-types": "off",
+
+        // sometimes a mock will have a single export and we're not picky about that
+        "import/prefer-default-export": "off"
       }
     }
   ],


### PR DESCRIPTION
Loosen rules about tests:
* we don't care about proptypes in mocks
* we don't care if a mock provides a single, non-default export

Loosen rules about what files are recognized as tests:
* they may be in /test
* they may be nested in /src/*/tests/
* they may be named *.test.js

Refs [ESCONF-20](https://issues.folio.org/browse/ESCONF-20)