### PR TITLE
ESCONF-26: Avoid enhanced-resolve ~5.11.0 due to incompatibilities with webpack-virtual-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for eslint-config-stripes
 
+
+## [6.3.1] IN PROGRESS
+
+* Avoid enhanced-resolve ~5.11.0 due to incompatibilities with webpack-virtual-config. Refs ESCONF-26.
+
 ## [6.3.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.2.0...v6.3.0)
 

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "webpack": "~5.68.0"
+  },
+  "resolutions": {
+    "enhanced-resolve": "~5.10.0"
   }
 }


### PR DESCRIPTION
Platform complete and individual modules are currently failing with:

https://jenkins-aws.indexdata.com/job/Automation/job/build-platform-complete-snapshot/13912/consoleText

This is due to the issue with `enhanced-resolve v5.11.0` (thank you @zburke for pointing to it):

https://github.com/webpack/enhanced-resolve/issues/362

This PR locks `enhanced-resolve` to `"~5.10.0"` 

Fixes [ESCONF-26](https://issues.folio.org/browse/ESCONF-26)