### PR TITLE
ESCONF-27: Remove enhanced-resolve resolutions entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "webpack": "~5.68.0"
-  },
-  "resolutions": {
-    "enhanced-resolve": "~5.10.0"
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/ESCONF-27

This PR reverts the changes from https://github.com/folio-org/eslint-config-stripes/pull/107 since this was fixed directly in webpack: https://github.com/webpack/enhanced-resolve/pull/364