### PR TITLE
Turn off semicolon rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = {
     "react/static-property-placement": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-
+    "semi": "off",
   },
   overrides: [
     {


### PR DESCRIPTION
Recent updates to eslint (v8x) changed semicolon rules and now apparently demands them in places where they were deemed unnecessary before. Modules can still enforce their own semicolon rules in their own repos if they feel the need.