### PR TITLE
ESCONF-29 satisfy all deps related to eslint as direct deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,6 @@
     "eslint",
     "eslintconfig"
   ],
-  "peerDependencies": {
-    "eslint": "^7.32.0"
-  },
-  "devDependencies": {
-    "eslint": "^7"
-  },
   "dependencies": {
     "@babel/core": "^7.18.13",
     "@babel/eslint-parser": "^7.15.0",
@@ -22,6 +16,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "babel-plugin-module-resolver": "^5.0.0",
+    "eslint": "^7.32.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.1",
@@ -32,6 +27,7 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
+    "typescript": "^4.9.4",
     "webpack": "~5.68.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "18.2.1",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import": "2.26.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@folio/stripes-webpack": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
-    "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint": "^7.32.0"
   },
   "devDependencies": {
-    "eslint": "^7.32.0"
+    "eslint": "^7"
   },
   "dependencies": {
     "@babel/core": "^7.18.13",
@@ -21,14 +21,17 @@
     "@folio/stripes-webpack": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-jest-dom": "^4.0.2",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-testing-library": "^5.6.0",
     "webpack": "~5.68.0"
   }
 }


### PR DESCRIPTION
Adding eslint-config-stripes to a repository should be an atomic action, i.e. eslint-config-stripes should be self-contained and not require adding any additional dev-deps. This will allow related dependencies are managed in a single place, reducing maintenance overhead from every repository to a single repository.

Refs [ESCONF-29](https://issues.folio.org/browse/ESCONF-29)