### PR TITLE
ESCONF-30 lock stripes-webpack to ~4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for eslint-config-stripes
 
+## 6.3.2 IN PROGRESS
+
+* Lock `stripes-webpack` to `~4.1` which finds its entrypoint in `stripes-core`. Refs ESCONF-30.
 
 ## [6.3.1](https://github.com/folio-org/eslint-config-stripes/tree/v6.3.1) (2022-11-23)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.3.0...v6.3.1)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/core": "^7.18.13",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^4.0.0",
+    "@folio/stripes-webpack": "~4.1.2",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "eslint-config-airbnb": "18.2.1",


### PR DESCRIPTION
Lock `stripes-webpack` to `~4.1.x`, the same version that will be used by `stripes-cli` `2.6.x`, in order to avoid pulling multiple different versions from being pulled into the bundle.

Refs [ESCONF-30](https://issues.folio.org/browse/ESCONF-30)