### PR TITLE
ESCONF-28 unpin webpack dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.5.0 IN PROGRESS
 
+* Unlock `webpack` from `~5.68.0`. Refs STCLI-222.
+
 ## [6.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.4.0) (2023-02-15)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.3.1...v6.4.0)
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
     "typescript": "^4.9.4",
-    "webpack": "~5.68.0"
+    "webpack": "^5.78.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
     "typescript": "^4.9.4",
-    "webpack": "^5.78.0"
+    "webpack": "^5.80.0"
   }
 }


### PR DESCRIPTION
We pinned webpack in [STCLI-195](https://issues.folio.org/browse/STCLI-195) but the build errors we encountered at that time have abated. 

Refs [ESCONF-28](https://issues.folio.org/browse/ESCONF-28)