### PR TITLE
ESCONF-32 update @folio/stripes-webpack to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for eslint-config-stripes
 
-## 6.5.0 IN PROGRESS
+## 7.0.0 IN PROGRESS
 
 * Unlock `webpack` from `~5.68.0`. Refs STCLI-222.
+* *BREAKING* Bump `@folio/stripes-webpack` to `5.0.0`. Refs ESCONF-32.
 
 ## [6.4.0](https://github.com/folio-org/eslint-config-stripes/tree/v6.4.0) (2023-02-15)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v6.3.1...v6.4.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "6.5.0",
+  "version": "7.0.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.18.13",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/stripes-webpack": "^4.2.0",
+    "@folio/stripes-webpack": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
*BREAKING* Bump `@folio/stripes-webpack` to v5. This is a breaking change even though `@folio/stripes-webpack` is a direct dependency because what we really need is for the version to be consistent _in dev deps_, which is sorta like a peer-dev-dep, but there is no such thing.

Refs [ESCONF-32](https://issues.folio.org/browse/ESCONF-32)