### PR TITLE
[ESCONF-38] Remove explicit typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
-    "typescript": "^4.9.4",
     "webpack": "^5.80.0"
   }
 }


### PR DESCRIPTION
# [Jira ESCONF-38](https://issues.folio.org/browse/ESCONF-38)

As part of [Jira STRIPES-900](https://issues.folio.org/browse/STRIPES-900), all modules should use one `typescript` version, inherited from `@folio/stripes-webpack`.  Therefore, the explicit `typescript` version in this `package.json` should be removed.