### PR TITLE
ESCONF-42: Turn off `import/prefer-default-export`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.2.0 IN PROGRESS
 
+* Turn off `import/prefer-default-export`. Refs ESCONF-42.
+
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
       "peerDependencies": true
     }],
     "import/no-unresolved": ["error", { "ignore": ["react", "react-dom", "stripes-config"] } ],
+    "import/prefer-default-export": "off",
     "jsx-a11y/anchor-is-valid": ["error", {
       "components": ["Link"],
       "specialLink": ["to"]


### PR DESCRIPTION
## Description
Turn off `import/prefer-default-export` since named export provides many advantages one of them is to have the same name in different files.

## Issue
[ESCONF-42](https://folio-org.atlassian.net/browse/ESCONF-42)