### PR TITLE
ESCONF-43 Set ESlint React version setting to `detect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.2.0 IN PROGRESS
 
+* Set ESlint React version setting to `detect`. Refs ESCONF-43.
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change history for eslint-config-stripes
 
-## 7.2.0 IN PROGRESS
+## 8.0.0 IN PROGRESS
 
-* Set ESlint React version setting to `detect`. Refs ESCONF-43.
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
+* *BREAKING* Set ESlint React version setting to `detect`. Refs ESCONF-43.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
       "webpack": {}
     },
     "react": {
-      "version": "16.3.0"
+      "version": "detect"
     },
   },
   "env": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eslint-config-stripes",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "The shared eslint configuration for stripes applications and extensions",
   "main": "index.js",
   "repository": "https://github.com/folio-org/eslint-config-stripes",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ESCONF-43

The React version ESlint setting effects the rule behavior of plugins like `eslint-plugin-react`. Having it set to an older React version leads to missing or incorrect linting results. By setting it to `detect`, the current React version will be automatically detected, ensuring up-to-date linting.