### PR TITLE
ESCONF-44 Update eslint-react-plugin to latest v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.2.0 IN PROGRESS
 
+* Update `eslint-plugin-react` to `^7.30.1`. Refs ESCONF-44.
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-jest-dom": "^4.0.2",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
-    "eslint-plugin-react": "7.30.1",
+    "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
     "webpack": "^5.80.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ESCONF-44

The version of `eslint-plugin-react` is currently fixed at `7.30.1`. Since then the plugin has received numerous [updates](https://github.com/jsx-eslint/eslint-plugin-react/blob/393bfa2fc071bfd08cef2327790e2ccc95507d72/CHANGELOG.md). By updating it to the latest v7 version developers can benefit from updated and added linting rules.