### PR TITLE
do not publish non-existent module descriptor

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -12,3 +12,5 @@ jobs:
       jest-enabled: false
       sonar-enabled: false
       compile-translations: false
+      publish-module-descriptor: false
+


### PR DESCRIPTION
We don't have an MD, so we better tell the workflow not to try to publish one.