### PR TITLE
ESCONF-49 turn off react/prop-types warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
 * *BREAKING* Bump `@folio/stripes-webpack` to `v6`.
+* Turn off `react/prop-types`. Refs ESCONF-49.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)

--- a/index.js
+++ b/index.js
@@ -87,9 +87,6 @@ module.exports = {
     "prefer-template": "off",
     "quote-props": "off",
     "react/destructuring-assignment": ["off"],
-    "react/forbid-prop-types": ["warn", {
-      "forbid": ["any", "array"]
-    }],
     "react/jsx-curly-newline": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-one-expression-per-line": "off",
@@ -98,6 +95,7 @@ module.exports = {
     "react/jsx-wrap-multilines": "off",
     "react/no-array-index-key": "off",
     "react/prefer-stateless-function": "off",
+    "react/prop-types": "off", // ESCONF-49
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",
     "react/sort-comp": ["warn", {
@@ -128,9 +126,6 @@ module.exports = {
         // lexically bound "this" prevents access to the Mocha test context.
         // See https://mochajs.org/#arrow-functions
         "prefer-arrow-callback": "off",
-
-        // we do not care about proptypes in mocks
-        "react/prop-types": "off",
 
         // sometimes a mock will have a single export and we're not picky about that
         "import/prefer-default-export": "off"


### PR DESCRIPTION
`prop-types` will be removed in React v19; there is no value in forcing people to maintain something that we know is about to be ignored.

Refs [ESCONF-49](https://folio-org.atlassian.net/browse/ESCONF-49)