### PR TITLE
ESCONF-50 loosen GA workflow constraint

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.6
+    uses: folio-org/.github/.github/workflows/ui.yml@v1
     secrets: inherit
     with:
       jest-enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
 * *BREAKING* Bump `@folio/stripes-webpack` to `v6`.
 * Turn off `react/prop-types`. Refs ESCONF-49.
+* Loosen GA workflow compatibility to `^1.0.0`. Refs ESCONF-50.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)


### PR DESCRIPTION
Provide `^1.0.0` compatibility.

Refs [ESCONF-50](https://folio-org.atlassian.net/browse/ESCONF-50)