### PR TITLE
ESCONF-52 permit string values in <FormattedNumber style>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * *BREAKING* Bump `@folio/stripes-webpack` to `v6`.
 * Turn off `react/prop-types`. Refs ESCONF-49.
 * Loosen GA workflow compatibility to `^1.0.0`. Refs ESCONF-50.
+* Allow `<FormattedNumber>` to accept string values in its `style` prop. Refs ESCONF-52.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ module.exports = {
     }],
     "react/state-in-constructor": "off",
     "react/static-property-placement": "off",
+    "react/style-prop-object": ["error", {
+      "allow": ["FormattedNumber"]
+    }],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
 


### PR DESCRIPTION
FormattedNumber expects string values in its `style` prop, but ESLint expects `style` to always correspond to an object for spreading CSS attributes onto the DOM. Whoops; that's [ESLint's mistake, not react-intl's](https://github.com/formatjs/formatjs/issues/833).

Refs [ESCONF-52](https://folio-org.atlassian.net/browse/ESCONF-52)