### PR TITLE
ESCONF-53 turn off react/forbid-prop-types warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Change history for eslint-config-stripes
 
-## 8.0.0 IN PROGRESS
+## IN PROGRESS
+
+* Turn off `react/forbid-prop-types`. Refs ESCONF-53.
+* Allow `<FormattedNumber>` to accept string values in its `style` prop. Refs ESCONF-52.
+
+## [8.0.1](https://github.com/folio-org/eslint-config-stripes/tree/v8.0.1) (2025-02-24)
+[Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v8.0.0...v8.0.1)
+
+* Loosen GA workflow compatibility to `^1.0.0`. Refs ESCONF-50.
+
+## [8.0.0](https://github.com/folio-org/eslint-config-stripes/tree/v8.0.0) (2025-02-24)
+[Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.1.0...v8.0.0)
 
 * Turn off `import/prefer-default-export`. Refs ESCONF-42.
 * *BREAKING* Bump `@folio/stripes-webpack` to `v6`.
 * Turn off `react/prop-types`. Refs ESCONF-49.
-* Loosen GA workflow compatibility to `^1.0.0`. Refs ESCONF-50.
-* Allow `<FormattedNumber>` to accept string values in its `style` prop. Refs ESCONF-52.
 
 ## [7.1.0](https://github.com/folio-org/eslint-config-stripes/tree/v7.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/eslint-config-stripes/compare/v7.0.0...v7.1.0)

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = {
     "react/no-array-index-key": "off",
     "react/prefer-stateless-function": "off",
     "react/prop-types": "off", // ESCONF-49
+    "react/forbid-prop-types": "off", // ESCONF-53, follow-up to ESCONF-49
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",
     "react/sort-comp": ["warn", {


### PR DESCRIPTION
`prop-types` will be removed in React 19. There is no value in warning people that their prop-types are underspecified given there will soon be no way to specify them at all.

This will eliminate the plague of
```
Prop type "object" is forbidden
```
lint warnings polluting our build logs. Given the "offending" code hasn't changed in ages, it sure would be nice to know why these warnings are suddenly showing up. Alas, not worth the effort.

Refs [ESCONF-53](https://folio-org.atlassian.net/browse/ESCONF-53)